### PR TITLE
Add personal brand landing page for Mauricio Quesada

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mauricio Quesada - Dibujante de Cómics y Mangas</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header class="hero">
+    <h1>Mauricio Quesada</h1>
+    <p>Dibujante de cómics y mangas · Especialista en Figma · Certificado esencial de Notion</p>
+    <div class="photo-wrapper">
+      <img class="rotating-photo" src="https://via.placeholder.com/300" alt="Foto de Mauricio Quesada" />
+    </div>
+  </header>
+
+  <section id="projects" class="section">
+    <h2>Proyectos</h2>
+    <div class="projects-grid">
+      <article class="card">
+        <h3>Mandarinita</h3>
+        <p>Historieta colorida con estilo tierno y vibrante.</p>
+        <a href="https://instagram.com/mandarinita" target="_blank" rel="noopener">Instagram de Mandarinita</a>
+      </article>
+      <article class="card">
+        <h3>Reverie</h3>
+        <p>Manga introspectivo lleno de sueños y acción.</p>
+        <a href="https://instagram.com/reverie" target="_blank" rel="noopener">Instagram de Reverie</a>
+      </article>
+      <article class="card">
+        <h3>Pétala</h3>
+        <p>Proyecto en pareja que explora la ilustración romántica.</p>
+        <a href="https://instagram.com/petala" target="_blank" rel="noopener">Instagram de Pétala</a>
+      </article>
+    </div>
+  </section>
+
+  <section id="skills" class="section">
+    <h2>Habilidades</h2>
+    <ul class="skills-list">
+      <li>Certificado esencial de Notion</li>
+      <li>Diseño de interfaces de usuario en Figma</li>
+      <li>Ilustración digital y narrativa visual</li>
+    </ul>
+  </section>
+
+  <section id="contact" class="section">
+    <h2>Contacto</h2>
+    <div class="contact-grid">
+      <a href="https://instagram.com/mandarinita" target="_blank" rel="noopener">Instagram Mandarinita</a>
+      <a href="https://instagram.com/reverie" target="_blank" rel="noopener">Instagram Reverie</a>
+      <a href="https://instagram.com/petala" target="_blank" rel="noopener">Instagram Pétala</a>
+      <a href="https://figma.com/@mauricio" target="_blank" rel="noopener">Figma</a>
+      <a href="https://x.com/mauricio" target="_blank" rel="noopener">X (Twitter)</a>
+      <a href="https://wa.me/" target="_blank" rel="noopener">WhatsApp</a>
+      <a href="https://t.me/" target="_blank" rel="noopener">Telegram</a>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <p>&copy; <span id="year"></span> Mauricio Quesada. Todos los derechos reservados.</p>
+  </footer>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,4 @@
+const yearSpan = document.getElementById('year');
+if (yearSpan) {
+  yearSpan.textContent = new Date().getFullYear();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,91 @@
+body {
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+  background: linear-gradient(135deg, #1a1a1a, #333);
+  color: #f5f5f5;
+  text-align: center;
+}
+
+.hero {
+  padding: 4rem 1rem 2rem;
+}
+
+.photo-wrapper {
+  margin-top: 2rem;
+}
+
+.rotating-photo {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  border: 4px solid #ff6b6b;
+  animation: spin 12s linear infinite;
+  box-shadow: 0 0 15px rgba(0,0,0,0.5);
+}
+
+@keyframes spin {
+  from { transform: rotateY(0deg); }
+  to { transform: rotateY(360deg); }
+}
+
+.section {
+  padding: 3rem 1rem;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.card {
+  background: #222;
+  padding: 1.5rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+}
+
+.card a {
+  color: #ff6b6b;
+  text-decoration: none;
+}
+
+.skills-list {
+  list-style: none;
+  padding: 0;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.skills-list li {
+  margin: 0.5rem 0;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.contact-grid a {
+  color: #f5f5f5;
+  background: #ff6b6b;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.contact-grid a:hover {
+  background: #ff8787;
+}
+
+.footer {
+  background: #111;
+  padding: 1rem 0;
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- Add single-page landing site with rotating profile photo and project showcase
- List Notion certificate and Figma UI design expertise
- Provide contact links for Mandarinita, Reverie, Pétala, Figma, X, WhatsApp, and Telegram

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b5dc8154c8332883ee7852b8244fd